### PR TITLE
Feature/validating beats

### DIFF
--- a/lib/jungle_beat.rb
+++ b/lib/jungle_beat.rb
@@ -38,4 +38,8 @@ class JungleBeat
   def play
     `say -r 500 -v Boing #{@list.to_string}`
   end
+
+  def all
+    @list.to_string
+  end
 end

--- a/lib/jungle_beat.rb
+++ b/lib/jungle_beat.rb
@@ -3,13 +3,20 @@ class JungleBeat
 
   def initialize
     @list = LinkedList.new
+    @valid_beats = ['tee', 'dee', 'deep', 'bop', 'boop',
+                    'la', 'na', 'doo', 'ditt', 'woo', 'hoo',
+                    'shu', 'mi', 'ray']
   end
 
   def append(data)
+    beats_added = 0
     data.split(" ").each do |data_string|
-      @list.append(data_string)
+      if @valid_beats.include?(data_string)
+        @list.append(data_string)
+        beats_added += 1
+      end
     end
-    data
+    beats_added
   end
 
   def count

--- a/lib/jungle_beat.rb
+++ b/lib/jungle_beat.rb
@@ -20,6 +20,17 @@ class JungleBeat
     beats_added
   end
 
+  def prepend(data)
+    beats_added = 0
+    data.split(" ").reverse.each do |data_string|
+      if @valid_beats.include?(data_string)
+        @list.prepend(data_string)
+        beats_added += 1
+      end
+    end
+    beats_added
+  end
+
   def count
     @list.count
   end

--- a/lib/jungle_beat.rb
+++ b/lib/jungle_beat.rb
@@ -1,11 +1,12 @@
 class JungleBeat
   attr_reader :list
 
-  def initialize
+  def initialize(data = '')
     @list = LinkedList.new
     @valid_beats = ['tee', 'dee', 'deep', 'bop', 'boop',
-                    'la', 'na', 'doo', 'ditt', 'woo', 'hoo',
-                    'shu', 'mi', 'ray']
+    'la', 'na', 'doo', 'ditt', 'woo', 'hoo',
+    'shu', 'mi', 'ray']
+    self.append(data)
   end
 
   def append(data)

--- a/spec/jungle_beat_spec.rb
+++ b/spec/jungle_beat_spec.rb
@@ -30,10 +30,11 @@ describe JungleBeat do
       expect(jb.list.to_string).to eq('deep doo ditt woo hoo shu')
     end
 
-    it 'returns the original data as a single string' do
+    it 'returns the number of beats successfully inserted' do
       jb = JungleBeat.new
 
-      expect(jb.append('deep doo ditt')).to eq('deep doo ditt')
+      expect(jb.append('deep doo ditt')).to eq(3)
+      expect(jb.append('deep doo ditt mississippi')).to eq(3)
     end
 
     it 'does nothing if the argument string is empty' do
@@ -41,6 +42,13 @@ describe JungleBeat do
       jb.append('')
 
       expect(jb.list.head).to eq(nil)
+    end
+
+    it 'rejects invalid beats' do
+      jb = JungleBeat.new
+      jb.append('deep')
+      
+      expect(jb.append('mississippi')).to eq(0)
     end
   end
 

--- a/spec/jungle_beat_spec.rb
+++ b/spec/jungle_beat_spec.rb
@@ -100,15 +100,21 @@ describe JungleBeat do
     end
   end
 
-  describe 'play' do
+  describe '#play' do
     it 'generates a JungleBeat string but returns nothing' do
       jb = JungleBeat.new
       jb.append('deep doo ditt woo hoo shu')
       
       expect(jb.play).to eq("")
     end
+  end
 
-    #listen for a sound! 
+  describe '#all' do
+    it 'returns a formatted string of all beats' do
+      jb = JungleBeat.new
+      jb.append('deep doo ditt woo hoo shu')
 
+      expect(jb.all).to eq('deep doo ditt woo hoo shu')
+    end
   end
 end

--- a/spec/jungle_beat_spec.rb
+++ b/spec/jungle_beat_spec.rb
@@ -45,10 +45,10 @@ describe JungleBeat do
     end
 
     it 'rejects invalid beats' do
-      jb = JungleBeat.new
-      jb.append('deep')
+      jb = JungleBeat.new('deep')
       
       expect(jb.append('mississippi')).to eq(0)
+      expect(jb.count).to eq(1)
     end
   end
 

--- a/spec/jungle_beat_spec.rb
+++ b/spec/jungle_beat_spec.rb
@@ -52,6 +52,39 @@ describe JungleBeat do
     end
   end
 
+  describe '#prepend' do
+    it 'adds seperate nodes to the beginning of the string' do
+      jb = JungleBeat.new
+      jb.append('deep doo ditt')
+      jb.prepend('woo hoo shu')
+
+      expect(jb.list.head.data).to eq('woo')
+      expect(jb.list.head.next_node.data).to eq('hoo')
+      expect(jb.list.to_string).to eq('woo hoo shu deep doo ditt')
+    end
+
+    it 'returns the number of beats successfully inserted' do
+      jb = JungleBeat.new
+
+      expect(jb.prepend('deep doo ditt')).to eq(3)
+      expect(jb.prepend('deep doo ditt mississippi')).to eq(3)
+    end
+
+    it 'does nothing if the argument string is empty' do
+      jb = JungleBeat.new
+      jb.prepend('')
+
+      expect(jb.list.head).to eq(nil)
+    end
+
+    it 'rejects invalid beats' do
+      jb = JungleBeat.new('deep')
+      
+      expect(jb.prepend('mississippi')).to eq(0)
+      expect(jb.count).to eq(1)
+    end
+  end
+
   describe '#count' do
     it 'returns 0 if the list is empty' do
       jb = JungleBeat.new


### PR DESCRIPTION
This pull request addresses [Iteration 4 Part 1 - Validating Beats](https://backend.turing.edu/module1/projects/jungle_beat/iteration_4).

The Jungle Beat class and test files have been updated to add 'prepend' and 'all' class methods, and to add validation to the 'append' method so that only valid beats can be added. When invalid beats are included as arguments, they are now ignored.  The methods have been updated to return the number of valid beats added to the JungleBeat, instead of returning the input data.