### PR TITLE
Feature/speed voice

### DIFF
--- a/lib/jungle_beat.rb
+++ b/lib/jungle_beat.rb
@@ -46,4 +46,12 @@ class JungleBeat
   def all
     @list.to_string
   end
+
+  def reset_rate
+    @rate = 500
+  end
+
+  def reset_voice
+    @voice = 'Boing'
+  end
 end

--- a/lib/jungle_beat.rb
+++ b/lib/jungle_beat.rb
@@ -1,11 +1,14 @@
 class JungleBeat
   attr_reader :list
+  attr_accessor :rate, :voice
 
   def initialize(data = '')
     @list = LinkedList.new
+    @rate = 500
+    @voice = 'Boing'
     @valid_beats = ['tee', 'dee', 'deep', 'bop', 'boop',
     'la', 'na', 'doo', 'ditt', 'woo', 'hoo',
-    'shu', 'mi', 'ray']
+    'shu', 'mi', 'ray', 'dop']
     self.append(data)
   end
 
@@ -36,7 +39,7 @@ class JungleBeat
   end
 
   def play
-    `say -r 500 -v Boing #{@list.to_string}`
+    `say -r #{@rate} -v #{@voice} #{@list.to_string}`
     @list.count
   end
 

--- a/lib/jungle_beat.rb
+++ b/lib/jungle_beat.rb
@@ -37,6 +37,7 @@ class JungleBeat
 
   def play
     `say -r 500 -v Boing #{@list.to_string}`
+    @list.count
   end
 
   def all

--- a/spec/jungle_beat_spec.rb
+++ b/spec/jungle_beat_spec.rb
@@ -101,11 +101,11 @@ describe JungleBeat do
   end
 
   describe '#play' do
-    it 'generates a JungleBeat string but returns nothing' do
+    it 'generates a JungleBeat string and returns number of beats' do
       jb = JungleBeat.new
       jb.append('deep doo ditt woo hoo shu')
       
-      expect(jb.play).to eq("")
+      expect(jb.play).to eq(6)
     end
   end
 

--- a/spec/jungle_beat_spec.rb
+++ b/spec/jungle_beat_spec.rb
@@ -118,3 +118,5 @@ describe JungleBeat do
     end
   end
 end
+
+require 'pry'; binding.pry

--- a/spec/jungle_beat_spec.rb
+++ b/spec/jungle_beat_spec.rb
@@ -117,6 +117,24 @@ describe JungleBeat do
       expect(jb.all).to eq('deep doo ditt woo hoo shu')
     end
   end
-end
 
-require 'pry'; binding.pry
+  describe '#reset_rate' do
+    it 'resets the rate variable to 500' do
+      jb = JungleBeat.new
+      jb.rate = 100
+      jb.reset_rate
+
+      expect(jb.rate).to eq(500)
+    end
+  end
+
+  describe '#reset_voice' do
+    it 'resets to voice variable to Boing' do
+      jb = JungleBeat.new
+      jb.voice = 'Daniel'
+      jb.reset_voice
+
+      expect(jb.voice).to eq('Boing')
+    end
+  end
+end


### PR DESCRIPTION
This pull request addresses [Iteration 4 Part 2: Speed & Voice](https://backend.turing.edu/module1/projects/jungle_beat/iteration_4).

The Jungle Beat class and test files have been updated to add rate and voice as instance variables with getter and setter methods accessible and default values. Methods to reset the rate and the voice back to the default values have also been added.  These new methods are tested in the spec file.

The original play method has been updated to use the rate and voice instance variable values when calling the 'say' command.