### PR TITLE
Add validation for voices

### DIFF
--- a/lib/jungle_beat.rb
+++ b/lib/jungle_beat.rb
@@ -1,15 +1,16 @@
 class JungleBeat
-  attr_reader :list
-  attr_accessor :rate, :voice
+  attr_reader :list, :voice
+  attr_accessor :rate
 
-  @@valid_beats = ['tee', 'dee', 'deep', 'bop', 'boop',
-  'la', 'na', 'doo', 'ditt', 'woo', 'hoo',
-  'shu', 'mi', 'ray', 'dop']
+  @@valid_beats = %w[tee dee deep bop boop la na doo ditt woo hoo shu mi ray dop]
+  @@valid_voices = %w[Daniel Boing Kathy Fred Ralph Albert Cellos]
+  @@default_voice = 'Boing'
+  @@default_rate = 500
 
   def initialize(data = '')
     @list = LinkedList.new
-    @rate = 500
-    @voice = 'Boing'
+    @rate = @@default_rate
+    @voice = @@default_voice
     append(data)
   end
 
@@ -48,11 +49,19 @@ class JungleBeat
     @list.to_string
   end
 
+  def voice=(voice)
+    if @@valid_voices.include?(voice)
+      @voice = voice
+    else
+      puts 'Sorry! This voice is not valid.'
+    end
+  end
+
   def reset_rate
-    @rate = 500
+    @rate = @@default_rate
   end
 
   def reset_voice
-    @voice = 'Boing'
+    @voice = @@default_voice
   end
 end

--- a/spec/jungle_beat_spec.rb
+++ b/spec/jungle_beat_spec.rb
@@ -119,8 +119,24 @@ describe JungleBeat do
     end
   end
 
+  describe '#voice=' do
+    it 'changes the voice if chosen voice is valid' do
+      jb = JungleBeat.new
+      jb.voice=('Daniel')
+
+      expect(jb.voice).to eq('Daniel')
+    end
+
+    it 'prints an error and keeps voice as-is if chosen voice is invalid' do
+      jb = JungleBeat.new
+      jb.voice=('Caroline')
+
+      expect(jb.voice).to eq('Boing')
+    end
+  end
+
   describe '#reset_rate' do
-    it 'resets the rate variable to 500' do
+    it 'resets the rate to 500' do
       jb = JungleBeat.new
       jb.rate = 100
       jb.reset_rate
@@ -130,7 +146,7 @@ describe JungleBeat do
   end
 
   describe '#reset_voice' do
-    it 'resets to voice variable to Boing' do
+    it 'resets to voice to Boing' do
       jb = JungleBeat.new
       jb.voice = 'Daniel'
       jb.reset_voice


### PR DESCRIPTION
This PR updates the voice setter method in the JungleBeat class to add validation, including a set list of valid voices available to the current Mac operating system. 

When an invalid voice is requested, the program prints an error message and the voice is not changed.  When a valid voice is requested, the voice is changed to the requested voice.