### PR TITLE
Update tests + code to handle edge cases

### DIFF
--- a/lib/jungle_beat.rb
+++ b/lib/jungle_beat.rb
@@ -50,11 +50,8 @@ class JungleBeat
   end
 
   def voice=(voice)
-    if @@valid_voices.include?(voice)
-      @voice = voice
-    else
-      puts 'Sorry! This voice is not valid.'
-    end
+    return unless @@valid_voices.include?(voice)
+    @voice = voice
   end
 
   def reset_rate

--- a/lib/jungle_beat.rb
+++ b/lib/jungle_beat.rb
@@ -2,7 +2,8 @@ class JungleBeat
   attr_reader :list, :voice
   attr_accessor :rate
 
-  @@valid_beats = %w[tee dee deep bop boop la na doo ditt woo hoo shu mi ray dop]
+  @@valid_beats = %w[tee dee deep bop boop la na doo ditt woo hoo
+                     shu mi ray dop]
   @@valid_voices = %w[Daniel Boing Kathy Fred Ralph Albert Cellos]
   @@default_voice = 'Boing'
   @@default_rate = 500
@@ -41,6 +42,7 @@ class JungleBeat
   end
 
   def play
+    return 'Sorry, this JungleBeat has no beats!' if @list.count == 0
     `say -r #{@rate} -v #{@voice} #{@list.to_string}`
     @list.count
   end

--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -66,6 +66,8 @@ class LinkedList
   end
 
   def find(position, num_elements)
+    return 'Sorry! This action cannot be completed.' if position > count-1
+
     current_node = @head
     found_elements = ''
     position.times { current_node = current_node.next_node }

--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -29,6 +29,8 @@ class LinkedList
   end
 
   def to_string
+    return 'Error - this list is empty.' if @head.nil?
+
     current_node = @head
     formatted_string = ''
     until current_node.nil?
@@ -83,10 +85,10 @@ class LinkedList
   end
 
   def pop
+    return 'Sorry! This action cannot be completed.' if @head.nil?
+
     current_node = @head
-    if current_node.nil?
-      return 'Sorry! This action cannot be completed.'
-    elsif current_node.next_node.nil?
+    if current_node.next_node.nil?
       removed_data = current_node.data
       @head = nil
     else

--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -84,11 +84,16 @@ class LinkedList
 
   def pop
     current_node = @head
-    until current_node.next_node.next_node.nil?
-      current_node = current_node.next_node
+    if current_node.nil?
+      return 'Sorry! This action cannot be completed.'
+    elsif current_node.next_node.nil?
+      removed_data = current_node.data
+      @head = nil
+    else
+      current_node = current_node.next_node until current_node.next_node.next_node.nil?
+      removed_data = current_node.next_node.data
+      current_node.next_node = nil
     end
-    removed_data = current_node.next_node.data
-    current_node.next_node = nil
     removed_data
   end
 end

--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -14,11 +14,11 @@ class LinkedList
         current_node = current_node.next_node
       end
       current_node.next_node = Node.new(data)
-    end    
+    end
     data
   end
 
-  def count    
+  def count
     counter = 0
     current_node = @head
     until current_node.nil?
@@ -39,7 +39,7 @@ class LinkedList
   end
 
   def prepend(data)
-    current_node = @head    
+    current_node = @head
     if current_node.nil?
       @head = Node.new(data)
     else
@@ -55,7 +55,9 @@ class LinkedList
     if current_node.nil?
       @head = Node.new(data)
     else
-      (position-1).times { current_node = current_node.next_node } 
+      return 'Sorry! This action cannot be completed.' if position > count
+
+      (position-1).times { current_node = current_node.next_node }
       new_node = Node.new(data)
       new_node.next_node = current_node.next_node
       current_node.next_node = new_node

--- a/spec/jungle_beat_spec.rb
+++ b/spec/jungle_beat_spec.rb
@@ -127,7 +127,7 @@ describe JungleBeat do
       expect(jb.voice).to eq('Daniel')
     end
 
-    it 'prints an error and keeps voice as-is if chosen voice is invalid' do
+    it 'keeps voice as-is if chosen voice is invalid' do
       jb = JungleBeat.new
       jb.voice=('Caroline')
 

--- a/spec/jungle_beat_spec.rb
+++ b/spec/jungle_beat_spec.rb
@@ -108,6 +108,12 @@ describe JungleBeat do
 
       expect(jb.play).to eq(6)
     end
+
+    it 'returns an error message if the JungleBeat has no beats' do
+      jb = JungleBeat.new
+
+      expect(jb.play).to eq('Sorry, this JungleBeat has no beats!')
+    end
   end
 
   describe '#all' do

--- a/spec/linked_list_spec.rb
+++ b/spec/linked_list_spec.rb
@@ -149,11 +149,11 @@ describe LinkedList do
       @list.append('blop')
     end
 
-    it 'returns an element from a specific position as a string' do
+    it 'returns an element from a specified position as a string' do
       expect(@list.find(2, 1)).to eq('shi')
     end
 
-    it 'returns more than one element if given an argument > 1' do
+    it 'returns the number of elements specified by argument' do
       expect(@list.find(1, 3)).to eq('woo shi shu')
     end
   end

--- a/spec/linked_list_spec.rb
+++ b/spec/linked_list_spec.rb
@@ -24,14 +24,14 @@ describe LinkedList do
       expect(@list.head).not_to eq(nil)
     end
 
-    it 'inserts a new node as the head if list is empty' do
+    it 'inserts a new node with specified data as the head, if list is empty' do
       @list.append('doop')
 
       expect(@list.head).to be_a Node
       expect(@list.head.data).to eq('doop')
     end
 
-    it 'inserts a new node at the end of the list if list is not empty' do
+    it 'inserts a new node with specified data at the end of the list' do
       @list.append('doop')
       @list.append('deep')
       @list.append('plop')
@@ -73,13 +73,13 @@ describe LinkedList do
   end
 
   describe '#prepend' do
-    it 'inserts a new node as the head if the list is empty' do
+    it 'inserts a new node with specified data as the head, if the list is empty' do
       @list.prepend('dop')
 
       expect(@list.head.data).to eq('dop')
     end
 
-    it 'adds a new node before existing nodes' do
+    it 'adds a new node with specified data before existing nodes' do
       @list.append('plop')
       @list.append('suu')
       @list.prepend('dop')
@@ -99,13 +99,13 @@ describe LinkedList do
   end
 
   describe '#insert' do
-    it 'inserts a new node as the head if the list is empty' do
+    it 'inserts a new node with specified data as the head, if the list is empty' do
       @list.insert(1, 'woo')
 
       expect(@list.head.data).to eq('woo')
     end
 
-    it 'adds a new element at a specific position' do
+    it 'adds a new node at a specific position' do
       @list.append('plop')
       @list.append('suu')
       @list.prepend('dop')
@@ -124,6 +124,15 @@ describe LinkedList do
       @list.insert(1, 'woo')
 
       expect(@list.insert(1, 'woo')).to eq('woo')
+    end
+
+    it 'returns an error and does not add node if the position does not exist in the list' do
+      @list.append('plop')
+      @list.append('suu')
+      @list.append('woo')
+
+      expect(@list.insert(4, 'dop')).to eq('Sorry! This action cannot be completed.')
+      expect(@list.count).to eq(3)
     end
   end
 

--- a/spec/linked_list_spec.rb
+++ b/spec/linked_list_spec.rb
@@ -198,5 +198,17 @@ describe LinkedList do
     it 'returns the last element from the list' do
       expect(@list.pop).to eq('blop')
     end
+
+    it 'resets the head to nil if it removes the only element' do
+      5.times { @list.pop }
+
+      expect(@list.head).to eq(nil)
+    end
+
+    it 'returns an error if the list is empty' do
+      5.times { @list.pop }
+
+      expect(@list.pop).to eq('Sorry! This action cannot be completed.')
+    end
   end
 end

--- a/spec/linked_list_spec.rb
+++ b/spec/linked_list_spec.rb
@@ -71,8 +71,8 @@ describe LinkedList do
       expect(@list.to_string).to eq('doop deep plop')
     end
 
-    it 'returns an empty string if list is empty' do
-      expect(@list.to_string).to eq('')
+    it 'returns an error message if list is empty' do
+      expect(@list.to_string).to eq('Error - this list is empty.')
     end
   end
 

--- a/spec/linked_list_spec.rb
+++ b/spec/linked_list_spec.rb
@@ -70,6 +70,10 @@ describe LinkedList do
       expect(@list.to_string).to be_a String
       expect(@list.to_string).to eq('doop deep plop')
     end
+
+    it 'returns an empty string if list is empty' do
+      expect(@list.to_string).to eq('')
+    end
   end
 
   describe '#prepend' do

--- a/spec/linked_list_spec.rb
+++ b/spec/linked_list_spec.rb
@@ -107,6 +107,7 @@ describe LinkedList do
       @list.insert(1, 'woo')
 
       expect(@list.head.data).to eq('woo')
+      expect(@list.head.next_node).to eq(nil)
     end
 
     it 'adds a new node at a specific position' do

--- a/spec/linked_list_spec.rb
+++ b/spec/linked_list_spec.rb
@@ -156,6 +156,10 @@ describe LinkedList do
     it 'returns the number of elements specified by argument' do
       expect(@list.find(1, 3)).to eq('woo shi shu')
     end
+
+    it 'returns an error if the position does not exist in the list' do
+      expect(@list.find(5, 1)).to eq('Sorry! This action cannot be completed.')
+    end
   end
 
   describe '#includes?' do


### PR DESCRIPTION
This PR includes commits to test for and address edge cases for methods in both the Linked List and Jungle Beat classes. 

Error message returns have been added and tested where needed, such as:
* to_string method, if called on an empty list
* insert method, if the given position is not in the list
* find method, if the given position is not in the list
* pop method, if called on an empty list
* play method, if called on an empty list

Additionally, this PR includes an update to the pop method so that it now resets the head of the list to 'nil' if the popped element was the previous head.